### PR TITLE
Fix loading of options

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,13 +9,13 @@ module.exports = {
   module: {
     rules: [{
       test: /\.html$/i,
+      enforce: 'pre',
       include: [
         // where your aurelia templates are contained:
         path.resolve('src')
       ],
       use: [{
         loader: 'aurelia-template-lint-webpack-loader',
-        enforce: 'pre',
         options: {
           // you can pass an configuration class
           // config reference https://github.com/MeirionHughes/aurelia-template-lint#config

--- a/index.ts
+++ b/index.ts
@@ -7,7 +7,7 @@ import {AureliaTemplateLintLoaderOptions} from './typings'
 import * as path from 'path'
 
 async function lint(input: string, loaderInstance: Webpack.Core.LoaderContext) {
-  const options = Object.assign({}, loaderUtils.parseQuery(loaderInstance.query)) as AureliaTemplateLintLoaderOptions
+  const options = Object.assign({}, loaderUtils.getOptions(loaderInstance)) as AureliaTemplateLintLoaderOptions
 
   // Get bail option
   const bailEnabled = loaderInstance.options.bail === true


### PR DESCRIPTION
@niieani this is a fix to load the options correctly or the new way.
https://github.com/webpack/loader-utils/issues/56

There is also a fix in the doc as it's not allowed to pass ```enforce``` in ```use```.